### PR TITLE
Integrate the generate prompt functionality with the CLI

### DIFF
--- a/.github/workflows/install_and_run.yml
+++ b/.github/workflows/install_and_run.yml
@@ -1,0 +1,26 @@
+name: Install and Run
+
+on:
+  workflow_dispatch:
+
+jobs:
+  install-and-run:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run create-swarm-agent
+      run: |
+        python cli/main.py create-swarm-agent "Your goal here" --output print

--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ python cli/main.py create-swarm-agent "Your goal here" --output [json|python|pri
 
 Replace `"Your goal here"` with the desired goal for the agent and choose the output format (`json`, `python`, or `print`).
 
-### Generating Prompts
+### Improving a Prompt
 
-To generate prompts using OpenAI's API, use the functionality provided in `cli/generate_prompt.py`.
+To improve a prompt using OpenAI's API, use the following command:
+
+```bash
+python cli/main.py improve-prompt "Your task or prompt here"
+```
+
+Replace `"Your task or prompt here"` with the task or prompt you want to improve.
 
 ## Examples
 
@@ -38,6 +44,14 @@ Example command to create a Swarm agent with a goal and output the Python code:
 
 ```bash
 python cli/main.py create-swarm-agent "Create a customer support agent" --output python
+```
+
+### Improving a Prompt
+
+Example command to improve a prompt:
+
+```bash
+python cli/main.py improve-prompt "Improve the following prompt: 'Translate the following English text to French.'"
 ```
 
 ### Generating Prompts

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,7 @@
 import argparse
 
 from agent_creator import create_swarm_agent
+from generate_prompt import generate_prompt
 
 def main():
     parser = argparse.ArgumentParser(description="OpenAI Swarm Agent Manager")
@@ -12,8 +13,9 @@ def main():
     
     parser_swarm.set_defaults(func=lambda args: create_swarm_agent(args.goal, args.output))
 
-    # parser_prompt = subparsers.add_parser('improve-prompt', help='Improve a prompt')
-    # parser_prompt.set_defaults(func=improve_prompt)
+    parser_prompt = subparsers.add_parser('improve-prompt', help='Improve a prompt')
+    parser_prompt.add_argument('task_or_prompt', type=str, help='The task or prompt to improve')
+    parser_prompt.set_defaults(func=lambda args: print(generate_prompt(args.task_or_prompt)))
 
     args = parser.parse_args()
     if args.command:


### PR DESCRIPTION
Integrate the `generate_prompt` functionality with the CLI.

* **cli/main.py**
  - Add a new subparser `improve-prompt` to the `argparse` setup.
  - Add an argument `task_or_prompt` to the `improve-prompt` subparser.
  - Import the `generate_prompt` function from `cli/generate_prompt.py`.
  - Set the default function for the `improve-prompt` subparser to call `generate_prompt`.

* **README.md**
  - Add usage instructions for the new `improve-prompt` command.
  - Provide an example command for the `improve-prompt` command.

